### PR TITLE
fix: set default storage on docker run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+: "${STORAGE_DIRECTORY:=etc/axoflow-otel-collector/storage}"
+
 detect_provider() {
     local provider=""
     local count=0


### PR DESCRIPTION
The helm-chart was correctly set-up to default the storage env-var, but with docker-run it was not present, the PR fixes that.
