### PR TITLE
chore: don't create unncessary pv's

### DIFF
--- a/charts/cloudconnectors/templates/pv.yaml
+++ b/charts/cloudconnectors/templates/pv.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.storage.customPVEnabled }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -14,3 +15,4 @@ spec:
   storageClassName: {{ .Values.storage.storageClassName }}
   hostPath:
     path: {{ include "cloudconnectors.storagePath" . }}
+{{- end }}

--- a/charts/cloudconnectors/values.yaml
+++ b/charts/cloudconnectors/values.yaml
@@ -54,6 +54,9 @@ storage:
   # -- Storage class name of the persistent volume claim
   storageClassName: ""
 
+  # -- Custom persistent volume enabled
+  customPVEnabled: false
+
 # -- List of environment variables to set in the container.
 env:
   # - name: "AXOROUTER_ENDPOINT"


### PR DESCRIPTION
The sts's PVCTemplate field will dynamically notify the default storageclass in the cluster to provision a pv for it, so there is no need to add our own pv, unless it is explicitly configured.