### PR TITLE
chore: followup component renamings

### DIFF
--- a/connectors/aws/config.yaml
+++ b/connectors/aws/config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp/axorouter:
+  otlp_grpc/axorouter:
     endpoint: ${env:AXOROUTER_ENDPOINT}
     retry_on_failure:
       enabled: true
@@ -69,4 +69,4 @@ service:
     logs:
       receivers: [awscloudwatch]
       processors: [resource/axoflow_device_id, resourcedetection/system, resource/axoflow]
-      exporters: [otlp/axorouter]
+      exporters: [otlp_grpc/axorouter]

--- a/connectors/azure/config.yaml
+++ b/connectors/azure/config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp/axorouter:
+  otlp_grpc/axorouter:
     endpoint: ${env:AXOROUTER_ENDPOINT}
     retry_on_failure:
       enabled: true
@@ -49,7 +49,7 @@ processors:
         value: "microsoft"
 
 receivers: # Provider specific!
-  azureeventhub:
+  azure_event_hub:
     connection: ${env:AZURE_EVENT_HUBS_CONNECTION_STRING}
     format: azure
     apply_semantic_conventions: true
@@ -66,6 +66,6 @@ service:
   extensions: [health_check, file_storage]
   pipelines:
     logs:
-      receivers: [azureeventhub]
+      receivers: [azure_event_hub]
       processors: [resource/axoflow_device_id, resourcedetection/system, resource/axoflow]
-      exporters: [otlp/axorouter]
+      exporters: [otlp_grpc/axorouter]

--- a/connectors/crowdstrike/config.yaml
+++ b/connectors/crowdstrike/config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp/axorouter:
+  otlp_grpc/axorouter:
     endpoint: ${env:AXOROUTER_ENDPOINT}
     retry_on_failure:
       enabled: true
@@ -87,4 +87,4 @@ service:
       receivers: [crowdstrike]
       processors:
         [resource/axoflow_device_id, resourcedetection/system, resource/axoflow]
-      exporters: [otlp/axorouter]
+      exporters: [otlp_grpc/axorouter]

--- a/connectors/kafka/config.yaml
+++ b/connectors/kafka/config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp/axorouter:
+  otlp_grpc/axorouter:
     endpoint: ${env:AXOROUTER_ENDPOINT}
     retry_on_failure:
       enabled: true
@@ -109,4 +109,4 @@ service:
     logs:
       receivers: [kafka]
       processors: [resource/axoflow_device_id, resourcedetection/system, resource/axoflow]
-      exporters: [otlp/axorouter]
+      exporters: [otlp_grpc/axorouter]


### PR DESCRIPTION
```
2026-05-06T12:40:17.232Z        warn    builders/builders.go:40 "otlp" alias is deprecated; use "otlp_grpc" instead     {"resource": {"service.instance.id": "f5e666b7-178c-4219-b7f4-edd324ca970f", "service.name": "axoflow-otel-collector", "service.version": "v0.150.0-axoflow.2"}, "otelcol.component.id": "otlp/axorouter", "otelcol.component.kind": "exporter", "otelcol.signal": "logs"}
2026-05-06T12:40:17.232Z        warn    builders/builders.go:40 "azureeventhub" alias is deprecated; use "azure_event_hub" instead      {"resource": {"service.instance.id": "f5e666b7-178c-4219-b7f4-edd324ca970f", "service.name": "axoflow-otel-collector", "service.version": "v0.150.0-axoflow.2"}, "otelcol.component.id": "azureeventhub", "otelcol.component.kind": "receiver", "otelcol.signal": "logs"}
```

- `awscloudwatch` still has not been renamed yet (will be `aws_cloudwatch`): https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e82773da1aa6816ea216a5b74de24a1752a74292/receiver/awscloudwatchreceiver/internal/metadata/generated_status.go#L12
- `kafka` will remain `kafka`: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e82773da1aa6816ea216a5b74de24a1752a74292/receiver/kafkareceiver/internal/metadata/generated_status.go#L12
- `crowdstrike` will likely remain `crowdstrike`, the receiver is managed by us