### PR TITLE
Add Tenable audit log cloud connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can find guides per connector:
 - [Kafka connector](./connectors/kafka/README.md#quickstart)
 - [Elasticsearch connector](./connectors/elasticsearch/README.md#quickstart)
 - [Idira connector](./connectors/idira/README.md#quickstart)
+- [Tenable connector](./connectors/tenable/README.md#quickstart)
 
 ## Environment Variables
 
@@ -172,6 +173,35 @@ You can find guides per connector:
 | `IDIRA_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS version to use. |
 | `IDIRA_TLS_MAX_VERSION` | No | - | Maximum TLS version to use. |
 | `IDIRA_TLS_INCLUDE_SYSTEM_CA_CERTS_POOL` | No | `false` | Include system CA certs along with provided CA. |
+
+### Tenable Provider
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TENABLE_ACCESS_KEY` | Yes | - | Tenable API access key (sent in the `X-ApiKeys` header). |
+| `TENABLE_SECRET_KEY` | Yes | - | Tenable API secret key. |
+| `TENABLE_ENDPOINT` | No | `https://cloud.tenable.com` | Base URL of the Tenable API. |
+| `TENABLE_POLL_INTERVAL` | No | `5m` | How often the audit log is queried. |
+| `TENABLE_PAGE_SIZE` | No | `1000` | Events requested per API call (max `5000`). |
+| `TENABLE_MAX_RECORDS_PER_POLL` | No | `5000` | Max events collected per poll; the remainder is picked up by the next poll. |
+| `TENABLE_INITIAL_LOOKBACK` | No | `24h` | How far back to collect when no checkpoint exists. Tenable retains 30 days. |
+| `TENABLE_TIMEOUT` | No | `30s` | HTTP request timeout. |
+
+#### TLS Settings
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TENABLE_TLS_INSECURE` | No | `false` | Disable TLS security (insecure). |
+| `TENABLE_TLS_INSECURE_SKIP_VERIFY` | No | `false` | Skip TLS certificate verification. |
+| `TENABLE_TLS_CA_FILE` | No | - | Path to a CA certificate file. |
+| `TENABLE_TLS_CA_PEM` | No | - | PEM-encoded CA certificate. |
+| `TENABLE_TLS_CERT_FILE` | No | - | Path to a client certificate file. |
+| `TENABLE_TLS_CERT_PEM` | No | - | PEM-encoded client certificate. |
+| `TENABLE_TLS_KEY_FILE` | No | - | Path to a client private key file. |
+| `TENABLE_TLS_KEY_PEM` | No | - | PEM-encoded client private key. |
+| `TENABLE_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS version to use. |
+| `TENABLE_TLS_MAX_VERSION` | No | - | Maximum TLS version to use. |
+| `TENABLE_TLS_INCLUDE_SYSTEM_CA_CERTS_POOL` | No | `false` | Include system CA certs along with provided CA. |
 
 
 ## Usage

--- a/connectors/tenable/README.md
+++ b/connectors/tenable/README.md
@@ -1,0 +1,73 @@
+# Tenable Audit Log Receiver
+
+This directory contains the Axoflow Tenable connector, which collects audit events from the Tenable
+Vulnerability Management audit log API (`/audit-log/v1/events`) and forwards them to Axorouter.
+
+Each audit event becomes one log record whose body is the raw event and whose timestamp comes from the
+event's `received` field. The connector follows pagination until the API stops returning a `next`
+token and persists its position to disk, so it resumes where it left off across restarts.
+
+## Quickstart
+
+Make sure the required environment variables are set before running the connector.
+
+```bash
+UUID_FULL=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
+AXOCLOUDCONNECTOR_DEVICE_ID=$(echo "$UUID_FULL" | cut -d'-' -f1)
+
+docker run \
+        --rm \
+        -v "${STORAGE_DIRECTORY}":"${STORAGE_DIRECTORY}" \
+        -e TENABLE_ACCESS_KEY="${TENABLE_ACCESS_KEY}" \
+        -e TENABLE_SECRET_KEY="${TENABLE_SECRET_KEY}" \
+        -e AXOROUTER_ENDPOINT="${AXOROUTER_ENDPOINT}" \
+        -e STORAGE_DIRECTORY="${STORAGE_DIRECTORY}" \
+        -e AXOCLOUDCONNECTOR_DEVICE_ID="${AXOCLOUDCONNECTOR_DEVICE_ID}" \
+        ghcr.io/axoflow/axocloudconnectors:latest
+```
+
+The API keys are generated in the Tenable UI under *My Account → API Keys*; the user needs permission
+to read the audit log.
+
+## Deploy with Helm-chart
+
+```bash
+make minikube-cluster
+make docker-build
+make minikube-load-image
+
+kubectl create namespace cloudconnectors
+kubectl create secret generic tenable \
+  --from-literal=access-key="<YOUR-TENABLE-ACCESS-KEY>" \
+  --from-literal=secret-key="<YOUR-TENABLE-SECRET-KEY>" \
+  --namespace cloudconnectors \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+UUID_FULL=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
+AXOCLOUDCONNECTOR_DEVICE_ID=$(echo "$UUID_FULL" | cut -d'-' -f1)
+
+helm upgrade --install --wait --namespace cloudconnectors cloudconnectors ./charts/cloudconnectors \
+  --set image.repository="axocloudconnectors" \
+  --set image.tag="dev" \
+  --set 'env[0].name=AXOROUTER_ENDPOINT' \
+  --set 'env[0].value=axorouter.axoflow-local.svc.cluster.local:4317' \
+  --set 'env[1].name=AXOCLOUDCONNECTOR_DEVICE_ID' \
+  --set "env[1].value=${AXOCLOUDCONNECTOR_DEVICE_ID}" \
+  --set 'env[2].name=TENABLE_ACCESS_KEY' \
+  --set 'env[2].valueFrom.secretKeyRef.name=tenable' \
+  --set 'env[2].valueFrom.secretKeyRef.key=access-key' \
+  --set 'env[3].name=TENABLE_SECRET_KEY' \
+  --set 'env[3].valueFrom.secretKeyRef.name=tenable' \
+  --set 'env[3].valueFrom.secretKeyRef.key=secret-key'
+```
+
+## Notes
+
+- A failed poll leaves the checkpoint untouched, so the next poll retries the same window rather than
+  skipping events. If the failure happens after part of a batch was already accepted, those events are
+  re-sent.
+- A `429 Too Many Requests` response suspends polling until the `Retry-After` deadline passes, falling
+  back to `TENABLE_POLL_INTERVAL` when the header is missing.
+- Tenable retains 30 days of audit events, so a `TENABLE_INITIAL_LOOKBACK` above `720h` gains nothing.
+- Events without a parseable `received` field are still forwarded, but cannot advance the checkpoint
+  and may be re-emitted while they remain inside the query window.

--- a/connectors/tenable/config.yaml
+++ b/connectors/tenable/config.yaml
@@ -1,0 +1,89 @@
+exporters:
+  otlp_grpc/axorouter:
+    endpoint: ${env:AXOROUTER_ENDPOINT}
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    sending_queue:
+      enabled: true
+      storage: file_storage
+    tls:
+      insecure: ${env:AXOROUTER_TLS_INSECURE:-false}
+      ca_file: ${env:AXOROUTER_TLS_CA_FILE}
+      ca_pem: ${env:AXOROUTER_TLS_CA_PEM}
+      cert_file: ${env:AXOROUTER_TLS_CERT_FILE}
+      cert_pem: ${env:AXOROUTER_TLS_CERT_PEM}
+      key_file: ${env:AXOROUTER_TLS_KEY_FILE}
+      key_pem: ${env:AXOROUTER_TLS_KEY_PEM}
+      min_version: ${env:AXOROUTER_TLS_MIN_VERSION:-1.2}
+      max_version: ${env:AXOROUTER_TLS_MAX_VERSION}
+      include_system_ca_certs_pool: ${env:AXOROUTER_TLS_INCLUDE_SYSTEM_CA_CERTS_POOL:-false}
+      insecure_skip_verify: ${env:AXOROUTER_TLS_INSECURE_SKIP_VERIFY:-false}
+
+processors:
+  resource/axoflow_device_id:
+    attributes:
+      - key: "com.axoflow.device_id"
+        action: insert
+        value: "${env:AXOCLOUDCONNECTOR_DEVICE_ID}"
+
+  resourcedetection/system:
+    detectors: ["system", "env"]
+    system:
+      hostname_sources: ["dns", "os", "cname", "lookup"]
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.ip:
+          enabled: true
+        host.id:
+          enabled: true
+
+  resource/axoflow: # Provider specific!
+    attributes:
+      - key: "com.axoflow.vendor"
+        action: insert
+        value: "tenable"
+      - key: "com.axoflow.product"
+        action: insert
+        value: "vulnerability-management"
+
+receivers: # Provider specific!
+  tenable_audit_log:
+    endpoint: ${env:TENABLE_ENDPOINT:-https://cloud.tenable.com}
+    access_key: ${env:TENABLE_ACCESS_KEY}
+    secret_key: ${env:TENABLE_SECRET_KEY}
+    poll_interval: ${env:TENABLE_POLL_INTERVAL:-5m}
+    page_size: ${env:TENABLE_PAGE_SIZE:-1000}
+    max_records_per_poll: ${env:TENABLE_MAX_RECORDS_PER_POLL:-5000}
+    initial_lookback: ${env:TENABLE_INITIAL_LOOKBACK:-24h}
+    timeout: ${env:TENABLE_TIMEOUT:-30s}
+    storage: file_storage
+    tls:
+      insecure: ${env:TENABLE_TLS_INSECURE:-false}
+      insecure_skip_verify: ${env:TENABLE_TLS_INSECURE_SKIP_VERIFY:-false}
+      ca_file: ${env:TENABLE_TLS_CA_FILE}
+      ca_pem: ${env:TENABLE_TLS_CA_PEM}
+      cert_file: ${env:TENABLE_TLS_CERT_FILE}
+      cert_pem: ${env:TENABLE_TLS_CERT_PEM}
+      key_file: ${env:TENABLE_TLS_KEY_FILE}
+      key_pem: ${env:TENABLE_TLS_KEY_PEM}
+      min_version: ${env:TENABLE_TLS_MIN_VERSION:-1.2}
+      max_version: ${env:TENABLE_TLS_MAX_VERSION}
+      include_system_ca_certs_pool: ${env:TENABLE_TLS_INCLUDE_SYSTEM_CA_CERTS_POOL:-false}
+
+extensions:
+  health_check:
+    endpoint: ${env:POD_IP}:13133
+  file_storage:
+    directory: ${env:STORAGE_DIRECTORY}
+    create_directory: true
+
+service:
+  extensions: [health_check, file_storage]
+  pipelines:
+    logs:
+      receivers: [tenable_audit_log]
+      processors:
+        [resource/axoflow_device_id, resourcedetection/system, resource/axoflow]
+      exporters: [otlp_grpc/axorouter]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ detect_provider() {
     env | grep -q "^CROWDSTRIKE_" && provider="$provider crowdstrike" && count=$((count + 1))
     env | grep -q "^ELASTICSEARCH_" && provider="$provider elasticsearch" && count=$((count + 1))
     env | grep -q "^IDIRA_" && provider="$provider idira" && count=$((count + 1))
+    env | grep -q "^TENABLE_" && provider="$provider tenable" && count=$((count + 1))
     # env | grep -q "^GCP_" && provider="$provider gcp" && count=$((count + 1))
 
     if [ "$count" -gt 1 ]; then
@@ -37,5 +38,6 @@ echo "   - Kafka (KAFKA_*)"
 echo "   - Crowdstrike (CROWDSTRIKE_*)"
 echo "   - Elasticsearch (ELASTICSEARCH_*)"
 echo "   - Idira (IDIRA_*)"
+echo "   - Tenable (TENABLE_*)"
 # echo "   - GCP (GCP_*)"
 exit 1


### PR DESCRIPTION
## Summary

Adds a `tenable` cloud connector that collects audit events from the Tenable Vulnerability
Management audit log API (`/audit-log/v1/events`) and forwards them to Axorouter, based on
[axoflow/opentelemetry-collector-contrib#37](https://github.com/axoflow/opentelemetry-collector-contrib/pull/37).

- `connectors/tenable/config.yaml` — `TENABLE_*`-driven `tenable_audit_log` receiver (X-ApiKeys
  access/secret key auth, paginated polling, checkpoint persisted to `file_storage`) wired through
  the standard axoflow processors to the `otlp_grpc/axorouter` exporter
- `entrypoint.sh` — provider auto-detection from `TENABLE_*` env vars
- root + connector README — documented variables, quickstart, and Helm deployment

Same 4-file shape as the elasticsearch connector (cdb92f2).

## ⚠️ Requires an image bump

The `tenable_audit_log` receiver is **not** in the currently pinned collector image. Verified:

    $ docker run --rm --entrypoint /axoflow-otel-collector \
        ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.152.0-axoflow.2 components

lists `crowdstrike` and `elasticsearchlogs`, but no tenable receiver. This connector will fail to
start until axoflow/opentelemetry-collector-contrib#37 is merged, released, and the `Dockerfile`
base image is bumped to a version that ships the receiver. The elasticsearch connector shipped
under the same caveat and was bumped separately in db297bd.

## Test plan

- [ ] Config YAML parses and resolves to the single `tenable_audit_log` receiver in the logs pipeline (checked locally)
- [ ] `TENABLE_ACCESS_KEY=…` alone makes `entrypoint.sh` select `connectors/tenable` (checked locally)
- [ ] After the image bump: `make docker-build` and run against a real Tenable tenant, confirm audit events reach Axorouter and the checkpoint survives a restart