### PR TITLE
feat: expose the productized crowdstrike receiver options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.156.0-axoflow.3 AS axo-otelcol
+FROM ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.156.0-axoflow.4 AS axo-otelcol
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS base
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ You can find guides per connector:
 | `CROWDSTRIKE_CLOUD` | No | - | Cloud region (e.g., `us-1`, `us-2`, `eu-1`, `us-gov-1`). |
 | `CROWDSTRIKE_HOST_OVERRIDE` | No | - | Optional override for API hostname. |
 | `CROWDSTRIKE_BASE_PATH_OVERRIDE` | No | - | Optional override for API base path. |
-| `CROWDSTRIKE_POLL_INTERVAL` | No | - | Poll interval for pulling logs/events. |
+| `CROWDSTRIKE_POLL_INTERVAL` | No | `30s` | Poll interval for pulling alerts and NG-SIEM events. |
+| `CROWDSTRIKE_INITIAL_LOOKBACK` | No | `0s` | How far back the first poll reaches. Only applies before a checkpoint exists; afterward collection resumes from the stored one. |
+| `CROWDSTRIKE_DISABLE_ALERTS` | No | `false` | Turns the Falcon Alerts poller off, e.g. to collect NG-SIEM events only. |
+| `CROWDSTRIKE_NGSIEM_REPOSITORY` | No | - | NG-SIEM repository (view) to pull log events from, e.g. `search-all`. Setting it enables the NG-SIEM search poller. |
+| `CROWDSTRIKE_NGSIEM_QUERY_STRING` | No | `*` | CQL filter selecting the NG-SIEM events to pull. Aggregating functions must not be used: every matched event becomes one log record. |
+| `CROWDSTRIKE_NGSIEM_POLL_INTERVAL` | No | `CROWDSTRIKE_POLL_INTERVAL` | Separate cadence for the NG-SIEM search poller; a query job costs far more than an alert page. |
 | `CROWDSTRIKE_DEBUG` | No | `false` | Enables verbose Crowdstrike API debugging. |
 
 #### TLS Settings

--- a/connectors/crowdstrike/README.md
+++ b/connectors/crowdstrike/README.md
@@ -1,7 +1,13 @@
 
 # CrowdStrike Falcon Receiver
 
-This directory contains the Axoflow CrowdStrike Falcon receiver which helps collecting alerts from the CrowdStrike Falcon platform.
+This directory contains the Axoflow CrowdStrike Falcon receiver, which collects
+alerts from the CrowdStrike Falcon platform and, optionally, the raw log events
+ingested into an NG-SIEM repository.
+
+Both pollers checkpoint their progress into `STORAGE_DIRECTORY`, so a restart
+resumes where the connector stopped instead of replaying or skipping data. Keep
+that directory on a volume that survives the container.
 
 ## Quickstart
 
@@ -108,3 +114,28 @@ helm upgrade --install --wait --namespace cloudconnectors cloudconnectors ./char
   --set 'env[3].valueFrom.secretKeyRef.key=cloud'
 ```
 
+## Collecting NG-SIEM log events
+
+Set `CROWDSTRIKE_NGSIEM_REPOSITORY` to the repository (view) to pull from; the
+poller stays off while it is empty. `CROWDSTRIKE_NGSIEM_QUERY_STRING` narrows
+the selection and `CROWDSTRIKE_NGSIEM_POLL_INTERVAL` gives that poller its own
+cadence, since a query job costs far more than an alert page.
+
+```bash
+docker run \
+        --rm \
+        -v "${STORAGE_DIRECTORY}":"${STORAGE_DIRECTORY}" \
+        -e CROWDSTRIKE_CLIENT_ID="${CROWDSTRIKE_CLIENT_ID}" \
+        -e CROWDSTRIKE_CLIENT_SECRET="${CROWDSTRIKE_CLIENT_SECRET}" \
+        -e CROWDSTRIKE_CLOUD="${CROWDSTRIKE_CLOUD}" \
+        -e CROWDSTRIKE_NGSIEM_REPOSITORY="${CROWDSTRIKE_NGSIEM_REPOSITORY}" \
+        -e CROWDSTRIKE_NGSIEM_POLL_INTERVAL="5m" \
+        -e AXOROUTER_ENDPOINT="${AXOROUTER_ENDPOINT}" \
+        -e STORAGE_DIRECTORY="${STORAGE_DIRECTORY}" \
+        -e AXOCLOUDCONNECTOR_DEVICE_ID="${AXOCLOUDCONNECTOR_DEVICE_ID}" \
+        ghcr.io/axoflow/axocloudconnectors:latest
+```
+
+Set `CROWDSTRIKE_DISABLE_ALERTS=true` to collect NG-SIEM events only. A
+repository must be configured in that case, otherwise the connector has nothing
+to collect and refuses to start.

--- a/connectors/crowdstrike/config.yaml
+++ b/connectors/crowdstrike/config.yaml
@@ -57,7 +57,14 @@ receivers: # Provider specific!
     cloud: ${env:CROWDSTRIKE_CLOUD}
     host_override: ${env:CROWDSTRIKE_HOST_OVERRIDE}
     base_path_override: ${env:CROWDSTRIKE_BASE_PATH_OVERRIDE}
-    poll_interval: ${env:CROWDSTRIKE_POLL_INTERVAL}
+    poll_interval: ${env:CROWDSTRIKE_POLL_INTERVAL:-30s}
+    initial_lookback: ${env:CROWDSTRIKE_INITIAL_LOOKBACK:-0s}
+    disable_alerts: ${env:CROWDSTRIKE_DISABLE_ALERTS:-false}
+    ngsiem_search:
+      repository: ${env:CROWDSTRIKE_NGSIEM_REPOSITORY}
+      query_string: ${env:CROWDSTRIKE_NGSIEM_QUERY_STRING}
+      poll_interval: ${env:CROWDSTRIKE_NGSIEM_POLL_INTERVAL:-0s}
+    storage: file_storage
     debug: ${env:CROWDSTRIKE_DEBUG:-false}
     tls:
       insecure: ${env:CROWDSTRIKE_TLS_INSECURE:-false}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,20 +2,42 @@
 
 set -eu
 
+# The collector reads this through ${env:STORAGE_DIRECTORY}, so the default has
+# to reach its environment, not just this shell.
 : "${STORAGE_DIRECTORY:=/var/lib/axoflow-otel-collector/storage}"
+export STORAGE_DIRECTORY
+
+# The collector expands ${env:VAR:-default} with POSIX `-` semantics: the
+# default applies only while VAR is unset. A variable that is set but empty --
+# `docker run -e VAR="${VAR}"` with no VAR in the shell, or a Helm `value: ""` --
+# resolves to null instead and overrides the default. Unset those.
+unset_empty_vars() {
+    local name
+    local value
+
+    for name in "$@"; do
+        eval "value=\${$name-}"
+        if [ -z "$value" ]; then
+            unset "$name"
+        fi
+    done
+}
 
 detect_provider() {
     local provider=""
     local count=0
 
-    env | grep -q "^AZURE_" && provider="$provider azure" && count=$((count + 1))
-    env | grep -q "^AWS_" && provider="$provider aws" && count=$((count + 1))
-    env | grep -q "^KAFKA_" && provider="$provider kafka" && count=$((count + 1))
-    env | grep -q "^CROWDSTRIKE_" && provider="$provider crowdstrike" && count=$((count + 1))
-    env | grep -q "^ELASTICSEARCH_" && provider="$provider elasticsearch" && count=$((count + 1))
-    env | grep -q "^IDIRA_" && provider="$provider idira" && count=$((count + 1))
-    env | grep -q "^TENABLE_" && provider="$provider tenable" && count=$((count + 1))
-    # env | grep -q "^GCP_" && provider="$provider gcp" && count=$((count + 1))
+    # `env` prints a set-but-empty variable as `VAR=`, and an empty one carries no
+    # configuration. The `=.` requires a value, so it does not select a provider --
+    # otherwise an empty leftover would be reported as a second one.
+    env | grep -q "^AZURE_[^=]*=." && provider="$provider azure" && count=$((count + 1))
+    env | grep -q "^AWS_[^=]*=." && provider="$provider aws" && count=$((count + 1))
+    env | grep -q "^KAFKA_[^=]*=." && provider="$provider kafka" && count=$((count + 1))
+    env | grep -q "^CROWDSTRIKE_[^=]*=." && provider="$provider crowdstrike" && count=$((count + 1))
+    env | grep -q "^ELASTICSEARCH_[^=]*=." && provider="$provider elasticsearch" && count=$((count + 1))
+    env | grep -q "^IDIRA_[^=]*=." && provider="$provider idira" && count=$((count + 1))
+    env | grep -q "^TENABLE_[^=]*=." && provider="$provider tenable" && count=$((count + 1))
+    # env | grep -q "^GCP_[^=]*=." && provider="$provider gcp" && count=$((count + 1))
 
     if [ "$count" -gt 1 ]; then
         echo "Multiple cloud providers detected:${provider}"
@@ -28,6 +50,18 @@ detect_provider() {
 
 if PROVIDER=$(detect_provider); then
     echo "Detected ${PROVIDER} configuration"
+
+    unset_empty_vars \
+        CROWDSTRIKE_POLL_INTERVAL \
+        CROWDSTRIKE_INITIAL_LOOKBACK \
+        CROWDSTRIKE_DISABLE_ALERTS \
+        CROWDSTRIKE_NGSIEM_POLL_INTERVAL \
+        CROWDSTRIKE_DEBUG \
+        CROWDSTRIKE_TLS_INSECURE \
+        CROWDSTRIKE_TLS_INSECURE_SKIP_VERIFY \
+        CROWDSTRIKE_TLS_MIN_VERSION \
+        CROWDSTRIKE_TLS_INCLUDE_SYSTEM_CA_CERTS_POOL
+
     exec ./axoflow-otel-collector --config "/etc/axoflow-otel-collector/connectors/${PROVIDER}/config.yaml"
 fi
 


### PR DESCRIPTION
## Summary

The CrowdStrike receiver gained checkpoint persistence, an NG-SIEM search poller and a separate cadence for it (axoflow/opentelemetry-collector-contrib#39). Wire the new options through the connector: point the receiver at the `file_storage` extension the connector already runs, so a restart resumes from the stored checkpoint instead of replaying or skipping data, and surface `initial_lookback`, `disable_alerts` and the `ngsiem_search` block as `CROWDSTRIKE_*` environment variables. `poll_interval` gains an explicit `30s` default.

The entrypoint now unsets `CROWDSTRIKE_*` variables that are set but empty: the collector expands `${env:VAR:-default}` with POSIX `-` semantics (default only when unset), so an empty variable — `docker run -e VAR="${VAR}"` with no VAR in the shell, or a Helm `value: ""` — would resolve to null, zero `poll_interval`, and fail the receiver's validation at startup.

## Requires an image bump

The Dockerfile references `axoflow-otel-collector:0.156.0-axoflow.4`, which is not published yet — it needs the receiver PR merged, a `receiver/crowdstrikereceiver/v0.156.0-axoflow.2` tag cut from it, and the releases-repo pin bumped and published (same dependency shape as the Idira connector, #26).

## Test plan

 - [x] Empty-env normalization verified in dash and busybox ash plus an end-to-end entrypoint run with a stub collector (empty vars removed, non-empty preserved, provider detection unaffected)
 - [x] Receiver behaviour behind these options live-validated against a Falcon tenant (checkpoint restart with zero redelivery/zero gap, dup-free NG-SIEM drain)
 - [ ] Full connector config validates once the `0.156.0-axoflow.4` image exists

---

Reviewed with: Claude Opus (adversarial review harness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CrowdStrike alert polling, initial lookback, and alert-disable settings.
  * Added optional NG-SIEM event collection with repository, query, and polling configuration.
  * Added persistent checkpoint storage support.
  * Empty CrowdStrike environment variables are now ignored so default settings apply.

* **Documentation**
  * Expanded setup and configuration guidance, including Docker usage and alert-only operation.

* **Chores**
  * Updated the OpenTelemetry Collector base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
